### PR TITLE
Fix typo in WebSocket setup

### DIFF
--- a/script.py
+++ b/script.py
@@ -144,7 +144,7 @@ async def setup_websockets():
             + suffix_id
         )
     else:
-        suffid_id = None
+        suffix_id = None
         pocketoption_session_id = os.getenv("DEMO_SESSION_ID")
         pocketoption_url = (
             "wss://demo-api-eu.po.market/socket.io/?EIO=4&transport=websocket"


### PR DESCRIPTION
## Summary
- fix variable name typo when using the demo account

## Testing
- `python -m py_compile script.py watcher.py external/random.py`


------
https://chatgpt.com/codex/tasks/task_e_68403969bbfc8333b2f2d08c6e81d038